### PR TITLE
Enable docker buildkit for distroless images

### DIFF
--- a/src/main/scala/com.snowplowanalytics.snowplow.sbt/SnowplowDistrolessDockerPlugin.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.sbt/SnowplowDistrolessDockerPlugin.scala
@@ -67,7 +67,11 @@ object SnowplowDistrolessDockerPlugin extends AutoPlugin {
       }
     },
     dockerAlias := dockerAlias.value.copy(tag = dockerAlias.value.tag.map(t => s"$t-distroless")),
-    dockerUpdateLatest := false
+    dockerUpdateLatest := false,
+    dockerBuildCommand := dockerBuildCommand.value.flatMap {
+      case "build" => Seq("buildx", "build")
+      case other => Seq(other)
+    }
   ) ++ inConfig(Docker)(
     Seq(
       daemonUserUid := None,


### PR DESCRIPTION
The distroless dockerfile assumes that [docker buildkit](https://docs.docker.com/build/buildkit/) is enabled.

Many people's development setup does not have buildkit enabled by default.  This leads to error messages when building the distroless image, like:

> [error] Error response from daemon: Dockerfile parse error line 6: Unknown flag: mount

We can avoid this error message by changing the docker build command to command to `docker buildx build` instead of the standard `docker build`.