### PR TITLE
Java 21 for snowplow docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: coursier/cache-action@v6
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v1
       with:
         java-version: 21

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 21
+    - name: Install sbt
+      uses: sbt/setup-sbt@v1
     - name: Check Scala formatting
       run: sbt scalafmtCheckAll
     - name: Deploy sbt-snowplow-release to Maven Central

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.4
+sbt.version=1.10.7

--- a/src/main/scala/com.snowplowanalytics.snowplow.sbt/IgluSchemaPlugin.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.sbt/IgluSchemaPlugin.scala
@@ -17,6 +17,7 @@ import sbt.Keys._
 import sbt.io.IO
 import scala.sys.process._
 import scala.util.matching.Regex
+import scala.language.postfixOps
 
 object IgluSchemaPlugin extends AutoPlugin {
 

--- a/src/main/scala/com.snowplowanalytics.snowplow.sbt/SnowplowDistrolessDockerPlugin.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.sbt/SnowplowDistrolessDockerPlugin.scala
@@ -14,14 +14,12 @@ package com.snowplowanalytics.snowplow.sbt
 
 import sbt._
 import sbt.Keys.artifactPath
-import com.typesafe.sbt.packager.docker.{Cmd, DockerPermissionStrategy, DockerPlugin, ExecCmd}
+import com.typesafe.sbt.packager.docker.{DockerPermissionStrategy, DockerPlugin}
 import com.typesafe.sbt.packager.linux.LinuxPlugin.autoImport._
 import com.typesafe.sbt.packager.archetypes.jar.LauncherJarPlugin
 import com.typesafe.sbt.packager.archetypes.jar.LauncherJarPlugin.autoImport.packageJavaLauncherJar
-import com.typesafe.sbt.packager.Keys.{maintainer, stage, stagingDirectory}
+import com.typesafe.sbt.packager.Keys.maintainer
 import DockerPlugin.autoImport._
-
-import scala.io.Source
 
 object SnowplowDistrolessDockerPlugin extends AutoPlugin {
 
@@ -29,66 +27,19 @@ object SnowplowDistrolessDockerPlugin extends AutoPlugin {
     val stageDistrolessInstallScript = taskKey[File]("Stage the install script for building distroless docker image")
   }
 
-  import autoImport._
-
   override def requires: Plugins = DockerPlugin && LauncherJarPlugin
 
   override def projectSettings: Seq[Setting[_]] = Seq(
-    dockerPermissionStrategy := DockerPermissionStrategy.CopyChown,
-    dockerBaseImage := "gcr.io/distroless/base-debian11:nonroot",
+    Docker / maintainer := "Snowplow Analytics Ltd. <support@snowplow.io>",
+    dockerBaseImage := "gcr.io/distroless/java21-debian12:nonroot",
+    Docker / daemonUser := "nonroot",
+    Docker / daemonGroup := "nonroot",
+    Docker / daemonUserUid := None,
     dockerRepository := Some("snowplow"),
-    dockerEntrypoint := Seq(
-      "/usr/lib/jvm/java-11-openjdk/bin/java",
-      "-jar",
-      s"/opt/snowplow/lib/${(packageJavaLauncherJar / artifactPath).value.getName}"
-    ),
-    dockerCommands := {
-      Seq(
-        Cmd("FROM", "debian:bullseye-slim", "AS", "bullseye"), // Provides standard linux executables for the install script
-        Cmd("COPY", "install.sh", "/usr/bin/"),
-        Cmd(
-          "FROM",
-          "gcr.io/distroless/java11-debian11:nonroot",
-          "AS",
-          "java"
-        ), // Provides a java installation compatible with the base image
-        Cmd("FROM", dockerBaseImage.value), // The true base image
-        Cmd("USER", "0"),
-        // Mount the filesystems of the build images and run the install script:
-        ExecCmd(
-          "RUN --mount=type=bind,from=bullseye,source=/,target=/bullseye --mount=type=bind,from=java,source=/,target=/java",
-          "/bullseye/bin/sh",
-          "/bullseye/usr/bin/install.sh"
-        ),
-        Cmd("ENV", "LANG=C.UTF-8")
-      ) ++ dockerCommands.value.tail.map {
-        case Cmd("USER", _*) => Cmd("USER", "nobody")
-        case Cmd("WORKDIR", _*) => Cmd("WORKDIR", "/tmp")
-        case other => other
-      }
-    },
-    dockerAlias := dockerAlias.value.copy(tag = dockerAlias.value.tag.map(t => s"$t-distroless")),
     dockerUpdateLatest := false,
-    dockerBuildCommand := dockerBuildCommand.value.flatMap {
-      case "build" => Seq("buildx", "build", "--load")
-      case other => Seq(other)
-    }
-  ) ++ inConfig(Docker)(
-    Seq(
-      daemonUserUid := None,
-      daemonGroup := "nonroot",
-      daemonUser := "nonroot",
-      maintainer := "Snowplow Analytics Ltd. <support@snowplow.io>",
-      defaultLinuxInstallLocation := "/opt/snowplow",
-      stage := (stage dependsOn stageDistrolessInstallScript).value,
-      stageDistrolessInstallScript := {
-        val f = stagingDirectory.value / "install.sh"
-
-        val stream = getClass.getClassLoader.getResourceAsStream("distroless/install.sh")
-        val content = Source.fromInputStream(stream).getLines // Warning: Source.fromResource does not work for a sbt plugin
-        IO.writeLines(f, content.toSeq)
-        f
-      }
-    )
+    Docker / defaultLinuxInstallLocation := "/home/snowplow",
+    dockerEntrypoint := Seq("java", "-jar", s"/home/snowplow/lib/${(packageJavaLauncherJar / artifactPath).value.getName}"),
+    dockerAlias := dockerAlias.value.copy(tag = dockerAlias.value.tag.map(t => s"$t-distroless")),
+    dockerPermissionStrategy := DockerPermissionStrategy.CopyChown
   )
 }

--- a/src/main/scala/com.snowplowanalytics.snowplow.sbt/SnowplowDockerPlugin.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.sbt/SnowplowDockerPlugin.scala
@@ -24,7 +24,7 @@ object SnowplowDockerPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Setting[_]] = Seq(
     Docker / maintainer := "Snowplow Analytics Ltd. <support@snowplow.io>",
-    dockerBaseImage := "eclipse-temurin:11-jre-focal",
+    dockerBaseImage := "eclipse-temurin:21-jre-noble",
     Docker / daemonUser := "snowplow",
     dockerRepository := Some("snowplow"),
     Docker / defaultLinuxInstallLocation := "/home/snowplow",


### PR DESCRIPTION
For the last few years, Snowplow has used Java 11.  For most apps we provide an image based off unbuntu, plus a distroless image, based off the google distroless project, which in turn was based off debian.

This PR upgrades to Java 21, the most recent LTS version. Our new app images use the following 3rd party base images:
- `eclipse-temurin:21-jre-noble`.  This base image uses ubuntu 24.04 (noble) and the eclipse temurin build of the JRE.
- `gcr.io/distroless/java21-debian12`. This distroless base image is extended from debian 12, and also uses the temurin build of the JRE

Before this PR, we had a much more complicated way of customizing the distroless image. But this was done mainly to exclude libssl (plus some other libs). The new distroless base image already exludes libssl, so it does not feel worth the effort of maintaining a complicated customization. So I have reverted back to using a simpler base image definition for the distroless image. The downside is we don't exclude quite so many libs as we did before, e.g. libexpat, which we previously excluded when there was an old CVE on an earlier version.