### PR TITLE
Add SnowplowSparkPlugin to build a self-deploying Spark distribution image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       uses: sbt/setup-sbt@v1
     - name: Check Scala formatting
       run: sbt scalafmtCheckAll
+    - name: Run scripted tests
+      run: sbt scripted
     - name: Deploy sbt-snowplow-release to Maven Central
       if: startsWith(github.ref, 'refs/tags/')
       run: sbt ci-release

--- a/README.md
+++ b/README.md
@@ -30,6 +30,69 @@ lazy val subproject = project
   .enablePlugins(SnowplowDistrolessDockerPlugin)
 ```
 
+### Snowplow Spark Plugin
+
+Configure an sbt project to build a self-contained, non-root Docker image containing a slimmed Apache Spark distribution, for running Spark on Kubernetes via Spark's native scheduler. The plugin owns the Spark version and pins a curated set of security-patched dependency versions (netty, jackson, log4j, and more) into the distribution, so CVE fixes are managed in one place; bump the plugin version to pick them up. There is no distroless variant, as Spark's entrypoint needs a shell.
+
+Compilation stays your project's responsibility: declare the Spark modules you build against as `provided` (so they compile but aren't bundled), using the plugin's `sparkVersion` setting so they match the shipped distribution, alongside your own non-Spark dependencies. The plugin then resolves the Spark distribution separately into `/opt/spark` and packages your application as a fat jar at `/opt/snowplow/app.jar`. Note that the distribution's jars take classpath precedence, so if you pin a library that Spark also ships, Spark's version wins at runtime (use `spark.driver.userClassPathFirst`/`spark.executor.userClassPathFirst` or shading if you need your version instead).
+
+```scala
+lazy val sparkApp = project
+  .enablePlugins(SnowplowSparkPlugin)
+  .settings(
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion.value % Provided,
+    // ... your own (non-Spark) dependencies
+  )
+```
+
+| Setting        | Default | Description |
+|----------------|---------|-------------|
+| `sparkVersion` | `4.1.2` | The Apache Spark version to bundle |
+| `sparkConfig`  | `Map.empty` | Intrinsic Spark conf baked into the image's `spark-defaults.conf` (see below) |
+
+#### Running the image
+
+The image is self-deploying: run it and it launches your application as the
+Spark driver. You do not run `spark-submit`, pass `driver`, name the main class,
+or know the jar path — the plugin's entrypoint does all of that. Pass
+spark-submit options directly, and separate any application arguments with a
+`--` sentinel:
+
+    docker run <image> <spark-submit options> -- <application args>
+
+For example, a Spark-on-Kubernetes driver pod passes its k8s master URL and
+per-deployment `--conf` options as the spark-submit options, then `--` and the
+application's own arguments. The first `--` is consumed as this separator, so
+a literal `--` cannot itself be passed through as an application argument.
+
+#### Intrinsic Spark configuration
+
+`sparkConfig` is for Spark configuration that is *intrinsic to your
+application* — conf it cannot run without, or that references your own code
+(e.g. a custom S3A credentials-provider class that lives in your jar). It is
+rendered into `/opt/spark/conf/spark-defaults.conf`, Spark's lowest-precedence
+conf source, so anything passed as `--conf` at deploy time overrides it.
+
+    sparkConfig := Map(
+      "spark.hadoop.fs.s3a.aws.credentials.provider" -> "com.example.MyCredentialsProvider"
+    )
+
+#### Overriding versions from your application
+
+Everything the plugin pins is a *default* — you can override any of it from your own build, so you never have to wait for a new plugin release to react to a CVE.
+
+Change the Spark version (this drives the whole distribution; keep your `provided` Spark deps on `sparkVersion.value` so they stay in lockstep):
+
+```scala
+sparkVersion := "4.1.3"
+```
+
+Bump a library the distribution ships — e.g. to take a netty or jackson fix early — by adding it to the `SparkDistribution` configuration. This affects the shipped distribution *only* (not your app's compile classpath), and Coursier's "highest version wins" pulls the version up:
+
+```scala
+// bump the specific module carrying the fix; its POM cascades matching siblings
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % SparkDistribution
+
 ### IgluSchemaPlugin
 
 This plugin adds Iglu schema files to your project's managed resources.  This is helpful if you use [iglu-scala-client](https://github.com/snowplow/iglu-scala-client) and you want the schemas to be fetched at compile time instead of run time.

--- a/build.sbt
+++ b/build.sbt
@@ -16,4 +16,5 @@ lazy val root = (project in file("."))
   .settings(BuildSettings.rootSettings)
   .settings(
     addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7"),
+    addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1"),
   )

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -18,6 +18,9 @@ import Keys._
 // dynver plugin
 import sbtdynver.DynVerPlugin.autoImport._
 
+// scripted plugin (bundled with sbt via SbtPlugin)
+import sbt.ScriptedPlugin.autoImport._
+
 object BuildSettings {
 
   lazy val buildSettings = Seq[Setting[_]](
@@ -42,6 +45,12 @@ object BuildSettings {
     )
   )
 
-  lazy val rootSettings = buildSettings ++ publishSettings
+  lazy val scriptedSettings = Seq[Setting[_]](
+    scriptedLaunchOpts := scriptedLaunchOpts.value ++
+      Seq("-Xmx1024M", s"-Dplugin.version=${version.value}"),
+    scriptedBufferLog := false
+  )
+
+  lazy val rootSettings = buildSettings ++ publishSettings ++ scriptedSettings
 
 }

--- a/src/main/resources/vendor/spark/README.md
+++ b/src/main/resources/vendor/spark/README.md
@@ -1,0 +1,38 @@
+# Vendored Apache Spark scripts
+
+These are third-party Apache Spark files, not Snowplow code, and keep their
+original ASF license headers. They are vendored because, unlike Spark's jars,
+they are not published to Maven.
+
+Provenance differs by file, and it matters:
+
+- **`bin/` scripts** (`spark-submit`, `spark-class`, `load-spark-env.sh`):
+  copied verbatim from the official Spark tarball `spark-4.1.2-bin-hadoop3.tgz`
+  (`bin/`). These are generic launchers, identical across the tarball and the
+  published image. This is the minimal driver-launch closure: the entrypoint's
+  driver branch execs `spark-submit` → `spark-class` → sources
+  `load-spark-env.sh`. `find-spark-home` is intentionally omitted — the launchers
+  only source it under `if [ -z "${SPARK_HOME}" ]`, and the image always sets
+  `SPARK_HOME=/opt/spark`, so that branch is never taken. (Executors don't use
+  the `bin/` scripts at all; they exec `java` directly.)
+
+- **`entrypoint.sh`**: copied verbatim from the **`apache/spark-docker`** repo
+  (`4.1.2/scala2.13-java17-ubuntu/entrypoint.sh`) — i.e. the entrypoint the
+  *published* `apache/spark:4.1.2` image ships, **not** the tarball's
+  `kubernetes/dockerfiles/spark/entrypoint.sh`. This is deliberate: the tarball /
+  Spark-source entrypoint writes a `java_opts.txt` file into the current working
+  directory, which fails under `readOnlyRootFilesystem: true` (the CWD is a
+  read-only image layer) and crash-fails the pod. The published-image entrypoint
+  assembles the executor Java opts in memory (`for v in "${!SPARK_JAVA_OPT_@}"`)
+  and writes nothing to the CWD, so it runs under a read-only root filesystem —
+  which is what our production Spark-on-k8s pods use, and what the current RDB
+  transformer image already relies on. The `spark/smoke` sbt-test's `readOnlyRun`
+  task guards against regressing to a CWD-writing entrypoint.
+
+`decom.sh` is intentionally **not** vendored: it is only used for executor
+decommissioning (disabled by default, and unused by our batch workloads), and
+nothing in the entrypoint or the `bin/` scripts references it.
+
+Re-vendor when the plugin's `sparkVersion` changes: `bin/` from the matching
+tarball, and `entrypoint.sh` from `apache/spark-docker` at the matching tag
+(never from the tarball's `kubernetes/dockerfiles/`).

--- a/src/main/resources/vendor/spark/bin/load-spark-env.sh
+++ b/src/main/resources/vendor/spark/bin/load-spark-env.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script loads spark-env.sh if it exists, and ensures it is only loaded once.
+# spark-env.sh is loaded from SPARK_CONF_DIR if set, or within the current directory's
+# conf/ subdirectory.
+
+# Figure out where Spark is installed
+if [ -z "${SPARK_HOME}" ]; then
+  source "$(dirname "$0")"/find-spark-home
+fi
+
+SPARK_ENV_SH="spark-env.sh"
+if [ -z "$SPARK_ENV_LOADED" ]; then
+  export SPARK_ENV_LOADED=1
+
+  export SPARK_CONF_DIR="${SPARK_CONF_DIR:-"${SPARK_HOME}"/conf}"
+
+  SPARK_ENV_SH="${SPARK_CONF_DIR}/${SPARK_ENV_SH}"
+  if [[ -f "${SPARK_ENV_SH}" ]]; then
+    # Promote all variable declarations to environment (exported) variables
+    set -a
+    . ${SPARK_ENV_SH}
+    set +a
+  fi
+fi
+
+# Setting SPARK_SCALA_VERSION if not already set.
+export SPARK_SCALA_VERSION=2.13
+#if [ -z "$SPARK_SCALA_VERSION" ]; then
+#  SCALA_VERSION_1=2.13
+#  SCALA_VERSION_2=2.12
+#
+#  ASSEMBLY_DIR_1="${SPARK_HOME}/assembly/target/scala-${SCALA_VERSION_1}"
+#  ASSEMBLY_DIR_2="${SPARK_HOME}/assembly/target/scala-${SCALA_VERSION_2}"
+#  ENV_VARIABLE_DOC="https://spark.apache.org/docs/latest/configuration.html#environment-variables"
+#  if [[ -d "$ASSEMBLY_DIR_1" && -d "$ASSEMBLY_DIR_2" ]]; then
+#    echo "Presence of build for multiple Scala versions detected ($ASSEMBLY_DIR_1 and $ASSEMBLY_DIR_2)." 1>&2
+#    echo "Remove one of them or, export SPARK_SCALA_VERSION=$SCALA_VERSION_1 in ${SPARK_ENV_SH}." 1>&2
+#    echo "Visit ${ENV_VARIABLE_DOC} for more details about setting environment variables in spark-env.sh." 1>&2
+#    exit 1
+#  fi
+#
+#  if [[ -d "$ASSEMBLY_DIR_1" ]]; then
+#    export SPARK_SCALA_VERSION=${SCALA_VERSION_1}
+#  else
+#    export SPARK_SCALA_VERSION=${SCALA_VERSION_2}
+#  fi
+#fi
+
+# Append jline option to enable the Beeline process to run in background.
+if [[ ( ! $(ps -o stat= -p $$ 2>/dev/null) =~ "+" ) && ! ( -p /dev/stdin ) ]]; then
+  export SPARK_BEELINE_OPTS="$SPARK_BEELINE_OPTS -Djline.terminal=jline.UnsupportedTerminal"
+fi

--- a/src/main/resources/vendor/spark/bin/spark-class
+++ b/src/main/resources/vendor/spark/bin/spark-class
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ -z "${SPARK_HOME}" ]; then
+  source "$(dirname "$0")"/find-spark-home
+fi
+
+. "${SPARK_HOME}"/bin/load-spark-env.sh
+
+# Find the java binary
+if [ -n "${JAVA_HOME}" ]; then
+  RUNNER="${JAVA_HOME}/bin/java"
+else
+  if [ "$(command -v java)" ]; then
+    RUNNER="java"
+  else
+    echo "JAVA_HOME is not set" >&2
+    exit 1
+  fi
+fi
+
+# Find Spark jars.
+if [ -d "${SPARK_HOME}/jars" ]; then
+  SPARK_JARS_DIR="${SPARK_HOME}/jars"
+else
+  SPARK_JARS_DIR="${SPARK_HOME}/assembly/target/scala-$SPARK_SCALA_VERSION/jars"
+fi
+
+if [ ! -d "$SPARK_JARS_DIR" ] && [ -z "$SPARK_TESTING$SPARK_SQL_TESTING" ]; then
+  echo "Failed to find Spark jars directory ($SPARK_JARS_DIR)." 1>&2
+  echo "You need to build Spark with the target \"package\" before running this program." 1>&2
+  exit 1
+else
+  LAUNCH_CLASSPATH="$SPARK_JARS_DIR/*"
+fi
+
+# Add the launcher build dir to the classpath if requested.
+if [ -n "$SPARK_PREPEND_CLASSES" ]; then
+  LAUNCH_CLASSPATH="${SPARK_HOME}/launcher/target/scala-$SPARK_SCALA_VERSION/classes:$LAUNCH_CLASSPATH"
+fi
+
+# For tests
+if [[ -n "$SPARK_TESTING" ]]; then
+  unset YARN_CONF_DIR
+  unset HADOOP_CONF_DIR
+fi
+
+# The launcher library will print arguments separated by a NULL character, to allow arguments with
+# characters that would be otherwise interpreted by the shell. Read that in a while loop, populating
+# an array that will be used to exec the final command.
+#
+# The exit code of the launcher is appended to the output, so the parent shell removes it from the
+# command array and checks the value to see if the launcher succeeded.
+build_command() {
+  "$RUNNER" -Xmx128m $SPARK_LAUNCHER_OPTS -cp "$LAUNCH_CLASSPATH" org.apache.spark.launcher.Main "$@"
+  printf "%d\0" $?
+}
+
+# Turn off posix mode since it does not allow process substitution
+set +o posix
+CMD=()
+DELIM=$'\n'
+CMD_START_FLAG="false"
+while IFS= read -d "$DELIM" -r _ARG; do
+  ARG=${_ARG//$'\r'}
+  if [ "$CMD_START_FLAG" == "true" ]; then
+    CMD+=("$ARG")
+  else
+    if [ "$ARG" == $'\0' ]; then
+      # After NULL character is consumed, change the delimiter and consume command string.
+      DELIM=''
+      CMD_START_FLAG="true"
+    elif [ "$ARG" != "" ]; then
+      echo "$ARG"
+    fi
+  fi
+done < <(build_command "$@")
+
+COUNT=${#CMD[@]}
+LAST=$((COUNT - 1))
+LAUNCHER_EXIT_CODE=${CMD[$LAST]}
+
+# Certain JVM failures result in errors being printed to stdout (instead of stderr), which causes
+# the code that parses the output of the launcher to get confused. In those cases, check if the
+# exit code is an integer, and if it's not, handle it as a special error case.
+if ! [[ $LAUNCHER_EXIT_CODE =~ ^[0-9]+$ ]]; then
+  echo "${CMD[@]}" | head -n-1 1>&2
+  exit 1
+fi
+
+if [ $LAUNCHER_EXIT_CODE != 0 ]; then
+  exit $LAUNCHER_EXIT_CODE
+fi
+
+CMD=("${CMD[@]:0:$LAST}")
+exec "${CMD[@]}"

--- a/src/main/resources/vendor/spark/bin/spark-submit
+++ b/src/main/resources/vendor/spark/bin/spark-submit
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ -z "${SPARK_HOME}" ]; then
+  source "$(dirname "$0")"/find-spark-home
+fi
+
+# disable randomized hash for string in Python 3.3+
+export PYTHONHASHSEED=0
+
+exec "${SPARK_HOME}"/bin/spark-class org.apache.spark.deploy.SparkSubmit "$@"

--- a/src/main/resources/vendor/spark/entrypoint.sh
+++ b/src/main/resources/vendor/spark/entrypoint.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Prevent any errors from being silently ignored
+set -eo pipefail
+
+attempt_setup_fake_passwd_entry() {
+  # Check whether there is a passwd entry for the container UID
+  local myuid; myuid="$(id -u)"
+  # If there is no passwd entry for the container UID, attempt to fake one
+  # You can also refer to the https://github.com/docker-library/official-images/pull/13089#issuecomment-1534706523
+  # It's to resolve OpenShift random UID case.
+  # See also: https://github.com/docker-library/postgres/pull/448
+  if ! getent passwd "$myuid" &> /dev/null; then
+      local wrapper
+      for wrapper in {/usr,}/lib{/*,}/libnss_wrapper.so; do
+        if [ -s "$wrapper" ]; then
+          NSS_WRAPPER_PASSWD="$(mktemp)"
+          NSS_WRAPPER_GROUP="$(mktemp)"
+          export LD_PRELOAD="$wrapper" NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+          local mygid; mygid="$(id -g)"
+          printf 'spark:x:%s:%s:${SPARK_USER_NAME:-anonymous uid}:%s:/bin/false\n' "$myuid" "$mygid" "$SPARK_HOME" > "$NSS_WRAPPER_PASSWD"
+          printf 'spark:x:%s:\n' "$mygid" > "$NSS_WRAPPER_GROUP"
+          break
+        fi
+      done
+  fi
+}
+
+if [ -z "$JAVA_HOME" ]; then
+  JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | awk '{print $3}')
+fi
+
+SPARK_CLASSPATH="$SPARK_CLASSPATH:${SPARK_HOME}/jars/*"
+for v in "${!SPARK_JAVA_OPT_@}"; do
+    SPARK_EXECUTOR_JAVA_OPTS+=( "${!v}" )
+done
+
+if [ -n "$SPARK_EXTRA_CLASSPATH" ]; then
+  SPARK_CLASSPATH="$SPARK_CLASSPATH:$SPARK_EXTRA_CLASSPATH"
+fi
+
+if ! [ -z "${PYSPARK_PYTHON+x}" ]; then
+    export PYSPARK_PYTHON
+fi
+if ! [ -z "${PYSPARK_DRIVER_PYTHON+x}" ]; then
+    export PYSPARK_DRIVER_PYTHON
+fi
+
+# If HADOOP_HOME is set and SPARK_DIST_CLASSPATH is not set, set it here so Hadoop jars are available to the executor.
+# It does not set SPARK_DIST_CLASSPATH if already set, to avoid overriding customizations of this value from elsewhere e.g. Docker/K8s.
+if [ -n "${HADOOP_HOME}"  ] && [ -z "${SPARK_DIST_CLASSPATH}"  ]; then
+  export SPARK_DIST_CLASSPATH="$($HADOOP_HOME/bin/hadoop classpath)"
+fi
+
+if ! [ -z "${HADOOP_CONF_DIR+x}" ]; then
+  SPARK_CLASSPATH="$HADOOP_CONF_DIR:$SPARK_CLASSPATH";
+fi
+
+if ! [ -z "${SPARK_CONF_DIR+x}" ]; then
+  SPARK_CLASSPATH="$SPARK_CONF_DIR:$SPARK_CLASSPATH";
+elif ! [ -z "${SPARK_HOME+x}" ]; then
+  SPARK_CLASSPATH="$SPARK_HOME/conf:$SPARK_CLASSPATH";
+fi
+
+# SPARK-43540: add current working directory into executor classpath
+SPARK_CLASSPATH="$SPARK_CLASSPATH:$PWD"
+
+# Switch to spark if no USER specified (root by default) otherwise use USER directly
+switch_spark_if_root() {
+  if [ $(id -u) -eq 0 ]; then
+    echo gosu spark
+  fi
+}
+
+case "$1" in
+  driver)
+    shift 1
+    CMD=(
+      "$SPARK_HOME/bin/spark-submit"
+      --conf "spark.driver.bindAddress=$SPARK_DRIVER_BIND_ADDRESS"
+      --conf "spark.executorEnv.SPARK_DRIVER_POD_IP=$SPARK_DRIVER_BIND_ADDRESS"
+      --deploy-mode client
+      "$@"
+    )
+    attempt_setup_fake_passwd_entry
+    # Execute the container CMD under tini for better hygiene
+    exec $(switch_spark_if_root) /usr/bin/tini -s -- "${CMD[@]}"
+    ;;
+  executor)
+    shift 1
+    CMD=(
+      ${JAVA_HOME}/bin/java
+      "${SPARK_EXECUTOR_JAVA_OPTS[@]}"
+      -Xms"$SPARK_EXECUTOR_MEMORY"
+      -Xmx"$SPARK_EXECUTOR_MEMORY"
+      -cp "$SPARK_CLASSPATH:$SPARK_DIST_CLASSPATH"
+      org.apache.spark.scheduler.cluster.k8s.KubernetesExecutorBackend
+      --driver-url "$SPARK_DRIVER_URL"
+      --executor-id "$SPARK_EXECUTOR_ID"
+      --cores "$SPARK_EXECUTOR_CORES"
+      --app-id "$SPARK_APPLICATION_ID"
+      --hostname "$SPARK_EXECUTOR_POD_IP"
+      --resourceProfileId "$SPARK_RESOURCE_PROFILE_ID"
+      --podName "$SPARK_EXECUTOR_POD_NAME"
+    )
+    attempt_setup_fake_passwd_entry
+    # Execute the container CMD under tini for better hygiene
+    exec $(switch_spark_if_root) /usr/bin/tini -s -- "${CMD[@]}"
+    ;;
+
+  *)
+    # Non-spark-on-k8s command provided, proceeding in pass-through mode...
+    exec "$@"
+    ;;
+esac

--- a/src/main/resources/vendor/spark/snowplow-entrypoint.sh.template
+++ b/src/main/resources/vendor/spark/snowplow-entrypoint.sh.template
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+case "$1" in
+  executor | history-server)
+    exec /opt/spark/entrypoint.sh "$@"
+    ;;
+  *)
+    spark_args=()
+    app_args=()
+    past_separator=false
+    for arg in "$@"; do
+      if [ "${arg}" = "--" ]; then
+        past_separator=true
+        continue
+      fi
+      if "${past_separator}"; then
+        app_args+=("${arg}")
+      else
+        spark_args+=("${arg}")
+      fi
+    done
+    exec /opt/spark/entrypoint.sh driver \
+      "${spark_args[@]}" \
+      --class "@MAIN_CLASS@" \
+      "local:///opt/snowplow/@JAR_NAME@" \
+      "${app_args[@]}"
+    ;;
+esac

--- a/src/main/scala/com.snowplowanalytics.snowplow.sbt/SnowplowSparkPlugin.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.sbt/SnowplowSparkPlugin.scala
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2022-2026 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.sbt
+
+import sbt._
+import sbt.Keys._
+import com.typesafe.sbt.packager.docker.DockerPlugin
+import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport._
+import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.Universal
+import com.typesafe.sbt.packager.linux.LinuxPlugin.autoImport.defaultLinuxInstallLocation
+import sbtassembly.AssemblyPlugin.autoImport._
+
+object SnowplowSparkPlugin extends AutoPlugin {
+
+  object autoImport {
+    val sparkVersion = settingKey[String]("Apache Spark version to bundle")
+    val stageSparkScripts = taskKey[Seq[(File, String)]]("Stage vendored Spark scripts and return docker mappings")
+    val sparkConfig = settingKey[Map[String, String]](
+      "Intrinsic Spark configuration rendered into the image's spark-defaults.conf"
+    )
+    val stageSparkDefaults = taskKey[(File, String)](
+      "Generate spark-defaults.conf from sparkConfig and return its docker mapping"
+    )
+    val stageSparkEntrypoint = taskKey[(File, String)](
+      "Generate the self-deploying Snowplow entrypoint and return its docker mapping"
+    )
+
+    // Dedicated Ivy configuration used to resolve the Spark
+    // distribution (spark-sql + spark-kubernetes and their patched transitive
+    // closure) independently of the app's own libraryDependencies. Kept separate
+    // from Compile/Runtime so a consuming app's non-Spark deps can never leak
+    // into /opt/spark/jars/. (The other half of the separation - keeping Spark
+    // out of the app's fat jar - is the app's own doing: it declares its Spark
+    // compile deps as Provided.)
+    val SparkDistribution = config("spark-distribution").hide
+  }
+
+  import autoImport._
+
+  override def requires: Plugins = SnowplowDockerPlugin && DockerPlugin
+
+  // Default versions the plugin bundles into the Spark distribution. `spark` is the Spark version itself;
+  // the rest are third-party libraries we forward-patch to mitigate CVEs.
+  //
+  // ALL of these are defaults a consuming app can override - only the mechanism
+  // differs: `spark` is exposed as the `sparkVersion` setting (override with
+  // `sparkVersion := "..."`, which also keeps the app's own Provided compile dep
+  // in lockstep), while the CVE pins are overridden by adding the artifact to the
+  // SparkDistribution config (Coursier highest-wins pulls it up) or a
+  // dependencyOverrides force.
+  private object V {
+    val spark = "4.1.2"
+    val netty = "4.2.15.Final"
+    val jackson = "2.21.4"
+    val log4j = "2.25.3"
+    val lz4Java = "1.8.1"
+    val zookeeper = "3.9.5"
+    val vertx = "4.5.27"
+    val parquetJackson = "1.17.1" // shades jackson 2.21.3
+    val hadoopClient = "3.4.3" // stays on Spark 4.1.2's Hadoop 3.4.x line
+  }
+
+  // Vendored resource path -> mapping path within the install location.
+  //
+  // Left: the file under src/main/resources/vendor/spark -- these are Apache
+  // Spark's own scripts, vendored verbatim (see that directory's README).
+  // Right: where it lands under the install location (spark/... => /opt/spark/...),
+  // i.e. the Spark distribution layout the vendored scripts expect.
+  //
+  // This is the minimal driver-launch closure: the entrypoint's driver branch
+  // execs bin/spark-submit, which execs bin/spark-class, which sources
+  // bin/load-spark-env.sh. (Executors don't use these -- they exec `java`
+  // directly.)
+  private val vendoredScripts = Seq(
+    "vendor/spark/bin/spark-submit" -> "spark/bin/spark-submit",
+    "vendor/spark/bin/spark-class" -> "spark/bin/spark-class",
+    "vendor/spark/bin/load-spark-env.sh" -> "spark/bin/load-spark-env.sh",
+    "vendor/spark/entrypoint.sh" -> "spark/entrypoint.sh"
+  )
+
+  // The Snowplow-owned entrypoint, generated at build time from the template
+  // resource because it bakes in the app's main class and jar filename. It sits
+  // IN FRONT of Spark's vendored /opt/spark/entrypoint.sh: executor/history-server
+  // dispatch straight through (the k8s executor-pod launch path must be
+  // untouched); everything else is treated as a driver launch. Caller args are
+  // split on a "--" sentinel so spark-submit options land before the jar and
+  // application args after it, matching the terraform driver-pod template's args
+  // layout. The template lives next to the vendored Spark scripts it wraps; its
+  // @MAIN_CLASS@/@JAR_NAME@ tokens (chosen so they can't collide with the
+  // script's own bash `${...}` expansions) are substituted here.
+  private val entrypointTemplateResource = "vendor/spark/snowplow-entrypoint.sh.template"
+
+  private def entrypointScript(mainClass: String, jarName: String): String =
+    readResource(entrypointTemplateResource).replace("@MAIN_CLASS@", mainClass).replace("@JAR_NAME@", jarName)
+
+  // Open a resource on the plugin's own classpath, failing loudly if it's absent
+  // (which would only happen if the plugin jar were built wrong).
+  private def resourceStream(resource: String): java.io.InputStream =
+    Option(getClass.getClassLoader.getResourceAsStream(resource))
+      .getOrElse(sys.error(s"vendored resource not found on plugin classpath: $resource"))
+
+  private def readResource(resource: String): String = {
+    val in = resourceStream(resource)
+    try scala.io.Source.fromInputStream(in, "UTF-8").mkString
+    finally in.close()
+  }
+
+  override lazy val globalSettings: Seq[Setting[_]] = Seq(
+    sparkVersion := V.spark,
+    sparkConfig := Map.empty
+  )
+
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+    ivyConfigurations += SparkDistribution,
+    // RUNTIME CLASSPATH PRECEDENCE (sharp edge): at runtime the Spark
+    // distribution's jars (/opt/spark/jars/*) precede the app fat jar on the
+    // driver/executor classpath by default. So if the app pins a library
+    // version that Spark ALSO ships transitively, Spark's version wins at
+    // runtime regardless of what the app declared here - the app's pin only
+    // affects compilation and what gets bundled, not resolution order. Apps
+    // that genuinely need their own version to win must opt into
+    // spark.driver.userClassPathFirst / spark.executor.userClassPathFirst, or
+    // shade the dependency in their assembly.
+    //
+    // These two modules seed the SparkDistribution resolution (see the config
+    // definition above). This is ONLY about packaging the distribution --
+    // compiling the app is the app's own responsibility: it declares whichever
+    // Spark modules it builds against (spark-sql, and possibly
+    // spark-hive/mllib/streaming) as `Provided`, on `sparkVersion.value` so the
+    // compile version stays in lockstep with the version shipped here.
+    libraryDependencies ++= Seq(
+      "org.apache.spark" %% "spark-sql" % sparkVersion.value,
+      "org.apache.spark" %% "spark-kubernetes" % sparkVersion.value
+    ).map(_ % SparkDistribution),
+    // Overrides to address CVEs in the versions Spark ships transitively. Scoped
+    // to SparkDistribution so they touch /opt/spark/jars/ only, never the app's
+    // Compile classpath; Coursier's highest-wins only ever pulls these up from
+    // Spark's baseline, never below it. The list grows as CVEs surface and shrinks
+    // as a sparkVersion bump makes entries redundant. Versions live in `V` above.
+    libraryDependencies ++= Seq(
+      "io.netty" % "netty-buffer" % V.netty,
+      "io.netty" % "netty-codec" % V.netty,
+      "io.netty" % "netty-codec-base" % V.netty,
+      "io.netty" % "netty-codec-classes-quic" % V.netty,
+      "io.netty" % "netty-codec-compression" % V.netty,
+      "io.netty" % "netty-codec-dns" % V.netty,
+      "io.netty" % "netty-codec-http" % V.netty,
+      "io.netty" % "netty-codec-http2" % V.netty,
+      "io.netty" % "netty-codec-http3" % V.netty,
+      "io.netty" % "netty-codec-marshalling" % V.netty,
+      "io.netty" % "netty-codec-protobuf" % V.netty,
+      "io.netty" % "netty-codec-socks" % V.netty,
+      "io.netty" % "netty-common" % V.netty,
+      "io.netty" % "netty-handler" % V.netty,
+      "io.netty" % "netty-handler-proxy" % V.netty,
+      "io.netty" % "netty-resolver" % V.netty,
+      "io.netty" % "netty-resolver-dns" % V.netty,
+      "io.netty" % "netty-transport" % V.netty,
+      "io.netty" % "netty-transport-classes-epoll" % V.netty,
+      "io.netty" % "netty-transport-classes-io_uring" % V.netty,
+      "io.netty" % "netty-transport-classes-kqueue" % V.netty,
+      "io.netty" % "netty-transport-native-unix-common" % V.netty,
+      "io.netty" % "netty-codec-native-quic" % V.netty,
+      "io.netty" % "netty-transport-native-epoll" % V.netty,
+      "io.netty" % "netty-transport-native-io_uring" % V.netty,
+      "io.netty" % "netty-transport-native-kqueue" % V.netty,
+      "com.fasterxml.jackson.core" % "jackson-databind" % V.jackson,
+      "com.fasterxml.jackson.core" % "jackson-core" % V.jackson,
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % V.jackson,
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % V.jackson,
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % V.jackson,
+      "org.apache.logging.log4j" % "log4j-core" % V.log4j,
+      "org.apache.logging.log4j" % "log4j-api" % V.log4j,
+      "org.apache.logging.log4j" % "log4j-1.2-api" % V.log4j,
+      "org.apache.logging.log4j" % "log4j-slf4j2-impl" % V.log4j,
+      "org.lz4" % "lz4-java" % V.lz4Java,
+      "org.apache.zookeeper" % "zookeeper" % V.zookeeper,
+      "org.apache.zookeeper" % "zookeeper-jute" % V.zookeeper,
+      "io.vertx" % "vertx-core" % V.vertx,
+      "org.apache.parquet" % "parquet-jackson" % V.parquetJackson,
+      "org.apache.hadoop" % "hadoop-client-runtime" % V.hadoopClient,
+      "org.apache.hadoop" % "hadoop-client-api" % V.hadoopClient
+    ).map(_ % SparkDistribution),
+    // The distribution provides the Scala library itself, so it must not be
+    // duplicated inside the app's fat jar.
+    assembly / assemblyPackageScala / assembleArtifact := false,
+    stageSparkScripts := {
+      val out = target.value / "spark-dist"
+      vendoredScripts.map { case (resource, mapping) =>
+        val dest = out / mapping
+        IO.createDirectory(dest.getParentFile)
+        val in = resourceStream(resource)
+        try IO.transfer(in, dest)
+        finally in.close()
+        dest.setExecutable(true, false)
+        dest -> mapping
+      }
+    },
+    stageSparkDefaults := {
+      val out = target.value / "spark-dist" / "spark-defaults.conf"
+      IO.createDirectory(out.getParentFile)
+      // Spark's spark-defaults.conf format is `key value` (space-separated),
+      // one per line. Sorted by key for a deterministic, diff-friendly file.
+      // Empty map => empty file (kept for a predictable layout; $SPARK_HOME/conf
+      // is already on the classpath per the vendored entrypoint).
+      val lines = sparkConfig.value.toSeq.sortBy(_._1).map { case (k, v) => s"$k $v" }
+      IO.write(out, lines.mkString("\n"))
+      out -> "spark/conf/spark-defaults.conf"
+    },
+    stageSparkEntrypoint := {
+      val cls = (Compile / mainClass).value.getOrElse(
+        sys.error(
+          "SnowplowSparkPlugin: could not determine the application main class. " +
+            "Set it explicitly, e.g. `Compile / mainClass := Some(\"com.example.Main\")`."
+        )
+      )
+      val jarName = (assembly / assemblyJarName).value
+      val out = target.value / "spark-dist" / "snowplow-entrypoint.sh"
+      IO.createDirectory(out.getParentFile)
+      IO.write(out, entrypointScript(cls, jarName))
+      out.setExecutable(true, false)
+      out -> "snowplow/entrypoint.sh"
+    },
+    Docker / defaultLinuxInstallLocation := "/opt",
+    Universal / mappings := {
+      // The Spark distribution jars, from the dedicated SparkDistribution config
+      // (NOT Runtime/dependencyClasspath, which carries the app's own deps).
+      val distJars = update.value
+        .select(configurationFilter(SparkDistribution.name))
+        .filter(f => f.isFile && f.getName.endsWith(".jar"))
+        .distinct
+      val jarMappings = distJars.map(j => j -> s"spark/jars/${j.getName}")
+      // The app, packaged as a fat jar: its own classes plus its non-Spark
+      // deps, with Spark (Provided) and the Scala library excluded.
+      val appJar = assembly.value
+      val scripts = stageSparkScripts.value
+      jarMappings ++ Seq(
+        appJar -> s"snowplow/${appJar.getName}",
+        stageSparkDefaults.value,
+        stageSparkEntrypoint.value
+      ) ++ scripts
+    },
+    dockerEntrypoint := Seq("/opt/snowplow/entrypoint.sh"),
+    // Each case below inserts a command exactly ONCE, keyed off a command that
+    // the single-stage CopyChown Dockerfile emits exactly once (FROM, WORKDIR,
+    // USER).
+    dockerCommands := dockerCommands.value.flatMap {
+      // The vendored entrypoint.sh is Apache Spark's own k8s image entrypoint,
+      // which unconditionally execs `/usr/bin/tini` as PID 1 for both the
+      // "driver" and "executor" dispatch branches. Our base image
+      // (eclipse-temurin, not Spark's own image) doesn't carry tini, so without
+      // this the entrypoint fails immediately with "No such file or directory".
+      // Installed while still root, i.e. before the USER nobody switch further
+      // down the command list.
+      case cmd @ com.typesafe.sbt.packager.docker.Cmd("FROM", _*) =>
+        Seq(
+          cmd,
+          com.typesafe.sbt.packager.docker.Cmd(
+            "RUN",
+            "apt-get update && apt-get install -y --no-install-recommends tini && rm -rf /var/lib/apt/lists/*"
+          )
+        )
+      case cmd @ com.typesafe.sbt.packager.docker.Cmd("WORKDIR", _*) =>
+        Seq(
+          com.typesafe.sbt.packager.docker.Cmd("ENV", "SPARK_HOME", "/opt/spark"),
+          com.typesafe.sbt.packager.docker.Cmd("ENV", "PATH", "/opt/spark/bin:$PATH"),
+          cmd
+        )
+      // Mirror Apache Spark's own k8s image: use /opt/spark/work-dir as a
+      // nobody-writable CWD. The auto-generated `WORKDIR /opt` is root-owned
+      // (COPY --chown only chowns /opt's *contents*), so as nobody any relative
+      // write there would fail; giving Spark a writable CWD keeps that safe (the
+      // vendored entrypoint also puts $PWD on the executor classpath per
+      // SPARK-43540). This runs as root, right before the USER switch and after
+      // the COPY that created /opt/spark, and (last-one-wins) overrides the
+      // earlier auto-generated `WORKDIR /opt`.
+      case cmd @ com.typesafe.sbt.packager.docker.Cmd("USER", _*) =>
+        Seq(
+          com.typesafe.sbt.packager.docker.Cmd(
+            "RUN",
+            "mkdir -p /opt/spark/work-dir && chown nobody:nogroup /opt/spark/work-dir"
+          ),
+          com.typesafe.sbt.packager.docker.Cmd("WORKDIR", "/opt/spark/work-dir"),
+          cmd
+        )
+      case other => Seq(other)
+    }
+  )
+}

--- a/src/sbt-test/spark/config/build.sbt
+++ b/src/sbt-test/spark/config/build.sbt
@@ -1,0 +1,56 @@
+lazy val root = (project in file("."))
+  .enablePlugins(SnowplowSparkPlugin)
+  .settings(
+    scalaVersion := "2.13.18",
+    name := "snowplow-spark-config",
+    version := "0.1.0",
+    Docker / packageName := "snowplow-spark-config",
+    Compile / mainClass := Some("example.Main"),
+    // Intrinsic, app-owned conf: two entries so we can assert ordering and
+    // that a value containing an '=' round-trips intact.
+    sparkConfig := Map(
+      "spark.hadoop.fs.s3a.aws.credentials.provider" -> "example.MyCredentialsProvider",
+      "spark.app.marker" -> "abc=def"
+    )
+  )
+
+// Assert sparkConfig renders into the staged spark-defaults.conf as `key value`
+// lines (space-separated, Spark's format), sorted by key, one per entry.
+TaskKey[Unit]("checkSparkConf") := {
+  val (file, mapping) = stageSparkDefaults.value
+  if (mapping != "spark/conf/spark-defaults.conf")
+    sys.error(s"unexpected spark-defaults mapping: $mapping")
+  val lines = IO.readLines(file).filter(_.trim.nonEmpty)
+  val expected = List(
+    "spark.app.marker abc=def",
+    "spark.hadoop.fs.s3a.aws.credentials.provider example.MyCredentialsProvider"
+  )
+  if (lines != expected)
+    sys.error(s"spark-defaults.conf mismatch.\n  expected: $expected\n  actual:   $lines")
+}
+
+// Assert the natural assembly jar name is preserved (not renamed to app.jar)
+// and that the generated Snowplow entrypoint bakes in the main class and that
+// exact jar name.
+TaskKey[Unit]("checkEntrypoint") := {
+  val paths = (Universal / mappings).value.map(_._2).toSet
+  if (paths.contains("snowplow/app.jar"))
+    sys.error("app jar must keep its natural assembly name, not app.jar")
+  val jarName = (assembly / assemblyJarName).value
+  if (!paths.contains(s"snowplow/$jarName"))
+    sys.error(s"app jar not mapped at snowplow/$jarName; mappings under snowplow/: " +
+      paths.filter(_.startsWith("snowplow/")).mkString(", "))
+
+  val (script, mapping) = stageSparkEntrypoint.value
+  if (mapping != "snowplow/entrypoint.sh")
+    sys.error(s"unexpected entrypoint mapping: $mapping")
+  if (!script.canExecute) sys.error("generated entrypoint is not executable")
+  val body = IO.read(script)
+  val q = "\""
+  if (!body.contains(s"--class ${q}example.Main${q}"))
+    sys.error(s"entrypoint does not reference the main class:\n$body")
+  if (!body.contains(s"${q}local:///opt/snowplow/$jarName${q}"))
+    sys.error(s"entrypoint does not reference the jar path local:///opt/snowplow/$jarName:\n$body")
+  if (!body.contains("executor | history-server"))
+    sys.error(s"entrypoint missing the executor/history-server passthrough:\n$body")
+}

--- a/src/sbt-test/spark/config/project/plugins.sbt
+++ b/src/sbt-test/spark/config/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.snowplowanalytics" % "sbt-snowplow-release" % x)
+  case None    => sys.error("The system property 'plugin.version' is not defined.")
+}

--- a/src/sbt-test/spark/config/src/main/scala/example/Main.scala
+++ b/src/sbt-test/spark/config/src/main/scala/example/Main.scala
@@ -1,0 +1,5 @@
+package example
+
+object Main {
+  def main(args: Array[String]): Unit = ()
+}

--- a/src/sbt-test/spark/config/test
+++ b/src/sbt-test/spark/config/test
@@ -1,0 +1,2 @@
+> checkSparkConf
+> checkEntrypoint

--- a/src/sbt-test/spark/override-sticks/build.sbt
+++ b/src/sbt-test/spark/override-sticks/build.sbt
@@ -1,0 +1,26 @@
+lazy val root = (project in file("."))
+  .enablePlugins(SnowplowSparkPlugin)
+  .settings(
+    scalaVersion := "2.13.18"
+  )
+
+// Assert the netty forward-patch actually landed on the resolved Spark
+// distribution: every io.netty jar except netty-tcnative-* (its own 2.0.x
+// scheme) and netty-all (an empty aggregator jar, deliberately left unpinned
+// at Spark's baseline - see SnowplowSparkPlugin's netty comment) must be the
+// pinned 4.2.15.Final.
+//
+// Spark is now Provided (compile-only, not on the Runtime classpath), so the
+// distribution's netty jars only exist in the dedicated SparkDistribution
+// config - that's where this must look, not Runtime/dependencyClasspath.
+TaskKey[Unit]("checkNetty") := {
+  val jarNames = update.value
+    .select(configurationFilter("spark-distribution"))
+    .map(_.getName)
+    .filter(n => n.startsWith("netty-") && !n.startsWith("netty-tcnative") && !n.startsWith("netty-all"))
+  if (jarNames.isEmpty) sys.error("No netty jars on the spark-distribution classpath")
+  val wrong = jarNames.filterNot(_.contains("4.2.15.Final"))
+  if (wrong.nonEmpty)
+    sys.error(s"Netty override did not stick; found: ${wrong.mkString(", ")}")
+  streams.value.log.info(s"netty override OK: ${jarNames.mkString(", ")}")
+}

--- a/src/sbt-test/spark/override-sticks/project/plugins.sbt
+++ b/src/sbt-test/spark/override-sticks/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.snowplowanalytics" % "sbt-snowplow-release" % x)
+  case None    => sys.error("The system property 'plugin.version' is not defined.")
+}

--- a/src/sbt-test/spark/override-sticks/test
+++ b/src/sbt-test/spark/override-sticks/test
@@ -1,0 +1,1 @@
+> checkNetty

--- a/src/sbt-test/spark/smoke/build.sbt
+++ b/src/sbt-test/spark/smoke/build.sbt
@@ -1,0 +1,148 @@
+lazy val root = (project in file("."))
+  .enablePlugins(SnowplowSparkPlugin)
+  .settings(
+    scalaVersion := "2.13.18",
+    name := "snowplow-spark-smoke",
+    version := "0.1.0",
+    Docker / packageName := "snowplow-spark-smoke",
+    Compile / mainClass := Some("example.Main"),
+    // The app declares its OWN Spark compile dependency, Provided (so it compiles
+    // against Spark but Spark is not bundled into the fat jar - the distribution
+    // supplies it at runtime), using the plugin's sparkVersion so the compile
+    // version matches what ships. The plugin does NOT inject this: compilation is
+    // the app's responsibility, packaging the distribution is the plugin's.
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion.value % Provided,
+    // The app's own, non-Spark dependency. cats-core is deliberately chosen
+    // because Spark is a Java project and ships no cats-* jar in its distribution
+    // closure, so if Main uses cats and the job runs, the only place cats could
+    // have come from is the app fat jar.
+    libraryDependencies += "org.typelevel" %% "cats-core" % "2.13.0"
+  )
+
+// Assert the staged docker mappings describe the expected distribution layout,
+// AND that the two halves (Spark distribution vs. app + its own deps) are
+// actually kept separate.
+TaskKey[Unit]("checkLayout") := {
+  val allMappings = (Universal / mappings).value
+  val paths = allMappings.map(_._2).toSet
+  if (paths.contains("snowplow/app.jar")) sys.error("app jar must keep its natural assembly name, not app.jar")
+  if (!paths.exists(p => p.startsWith("snowplow/") && p.endsWith(".jar")))
+    sys.error("app jar not mapped under snowplow/")
+  if (!paths.contains("snowplow/entrypoint.sh")) sys.error("snowplow/entrypoint.sh (self-deploying wrapper) not mapped")
+  if (!paths.contains("spark/entrypoint.sh")) sys.error("vendored spark/entrypoint.sh not mapped")
+  val sparkJars = paths.count(p => p.startsWith("spark/jars/") && p.endsWith(".jar"))
+  if (sparkJars < 100) sys.error(s"expected the full Spark jar closure under spark/jars/, found $sparkJars")
+  val appJarInSparkJars = paths.exists(p => p.startsWith("spark/jars/") && p.contains("snowplow-spark-smoke"))
+  if (appJarInSparkJars) sys.error("app jar must NOT be under spark/jars/")
+  // The app's own dependency (cats-core) must live only in the fat jar, never
+  // in the Spark distribution. Spark ships no cats-* jar, so a bare module-name
+  // check is both correct and clean here.
+  val catsInSparkJars = paths.exists(p => p.startsWith("spark/jars/") && p.split('/').last.startsWith("cats-"))
+  if (catsInSparkJars) sys.error("app's own dependency (cats-*) must NOT leak into spark/jars/")
+  // The smoke fixture uses the default (empty) sparkConfig, so the rendered
+  // spark-defaults.conf should be empty - exercises the empty-map path.
+  val defaultsFile = allMappings
+    .collectFirst { case (f, "spark/conf/spark-defaults.conf") => f }
+    .getOrElse(sys.error("spark/conf/spark-defaults.conf not mapped"))
+  if (IO.read(defaultsFile).trim.nonEmpty)
+    sys.error("default (empty) sparkConfig should render an empty spark-defaults.conf")
+}
+
+// Runs the built image as the non-root nobody user (UID 65534), driving a
+// shuffle job via local-cluster so netty block transfer and jackson
+// serialization across real executor JVMs are exercised.
+TaskKey[Unit]("smokeRun") := {
+  import scala.sys.process._
+  val log = streams.value.log
+  val image = s"snowplow/${(Docker / packageName).value}:${version.value}"
+
+  // Belt-and-braces: assert the plugin's dockerCommands ENV transform actually
+  // landed. If native-packager ever stops emitting a WORKDIR command, the
+  // transform in SnowplowSparkPlugin silently skips inserting SPARK_HOME/PATH,
+  // and spark-submit would fail later with an obscure "command not found"
+  // rather than a clear signal about the missing env.
+  val envCheckCmd = Seq(
+    "docker", "run", "--rm", "--user", "65534", "--entrypoint", "sh", image,
+    "-c", "[ \"$SPARK_HOME\" = /opt/spark ] && echo \"$PATH\" | grep -q /opt/spark/bin"
+  )
+  log.info(envCheckCmd.mkString(" "))
+  val envCheckCode = envCheckCmd.!
+  if (envCheckCode != 0)
+    sys.error(s"SPARK_HOME/PATH env check failed with exit code $envCheckCode - dockerCommands ENV transform may have regressed")
+
+  val containerName = "snowplow-spark-smoke-run"
+  val cmd = Seq(
+    "docker", "run", "--rm", "--name", containerName, "--user", "65534",
+    // local-cluster runs the driver AND both executors inside this one
+    // container, all talking over the driver's RPC port. Force the driver to
+    // bind and advertise loopback so the in-container executors can actually
+    // reach it - without this the driver advertises the container hostname but
+    // binds elsewhere, executors get "Connection refused", and each failed
+    // registration resets the standalone retry counter into an infinite
+    // relaunch loop. SPARK_DRIVER_BIND_ADDRESS feeds the entrypoint's
+    // --conf spark.driver.bindAddress; SPARK_LOCAL_IP pins block-manager
+    // endpoints; spark.driver.host fixes the advertised address.
+    "-e", "SPARK_DRIVER_BIND_ADDRESS=127.0.0.1",
+    "-e", "SPARK_LOCAL_IP=127.0.0.1",
+    // NOTE: deliberately NO `-w` here. Running with the image's own WORKDIR
+    // (/opt/spark/work-dir, created nobody-writable by the plugin) proves the
+    // non-root posture end to end, exactly as k8s driver/executor pods do.
+    image,
+    // Self-deploying: no `driver`, no `--class`, no jar path. These are all
+    // spark-submit options, and the wrapper entrypoint synthesises the rest.
+    // This exercises the real production entrypoint path end to end.
+    "--master", "local-cluster[2,1,1024]",
+    "--conf", "spark.driver.host=127.0.0.1",
+    // Defensive fail-fast: cap standalone executor relaunches so a future
+    // misconfig surfaces as a job failure rather than an infinite loop.
+    "--conf", "spark.deploy.maxExecutorRetries=2",
+    // Sentinel + application arg: proves the wrapper entrypoint routes
+    // pre-"--" tokens to spark-submit (the job runs) and post-"--" tokens to
+    // the application (Main's require passes). Without the split working, the
+    // job would either fail to submit or Main would abort.
+    "--", "--smoke-marker"
+  )
+  log.info(cmd.mkString(" "))
+
+  // Hard timeout in the task itself (no reliance on a `timeout` binary, which
+  // is not present on macOS). A correct run finishes in well under 2 minutes;
+  // if we blow past the deadline something is wrong (e.g. an executor relaunch
+  // loop), so force-kill the container and the process and fail loudly.
+  val deadlineMs = 300000L
+  val proc       = cmd.run(true)
+  val started    = System.currentTimeMillis()
+  while (proc.isAlive() && System.currentTimeMillis() - started < deadlineMs)
+    Thread.sleep(1000L)
+  if (proc.isAlive()) {
+    Seq("docker", "kill", containerName).!
+    proc.destroy()
+    sys.error(s"spark smoke job timed out after ${deadlineMs / 1000}s - killed container $containerName")
+  }
+  val code = proc.exitValue()
+  if (code != 0) sys.error(s"spark smoke job failed with exit code $code")
+}
+
+// Read-only-root-filesystem regression guard. The production k8s driver pod
+// runs with `readOnlyRootFilesystem: true` and only /tmp mounted writable, so
+// the vendored entrypoint must NOT write anything into its CWD (a read-only
+// image layer). We vendor Apache Spark's *published-image* entrypoint (in-memory
+// SPARK_JAVA_OPT_ expansion) precisely because the source-tree/tarball variant
+// wrote `java_opts.txt` into the CWD and crash-failed under this posture.
+//
+// This drives the `executor` branch under `docker run --read-only`, which hits
+// the same entrypoint preamble as the driver but fails fast (no driver URL) once
+// it reaches the JVM - all we assert is that the read-only CWD is never touched,
+// i.e. the output never contains "Read-only file system". A regression to the
+// CWD-writing entrypoint would reintroduce that error and fail this guard.
+TaskKey[Unit]("readOnlyRun") := {
+  import scala.sys.process._
+  val log = streams.value.log
+  val image = s"snowplow/${(Docker / packageName).value}:${version.value}"
+  val cmd = Seq("docker", "run", "--rm", "--read-only", "--user", "65534", image, "executor")
+  log.info(cmd.mkString(" "))
+  val out = new StringBuilder
+  val logger = ProcessLogger(line => out.append(line).append('\n'))
+  cmd.run(logger).exitValue() // expected non-zero: executor bails without a driver, that's fine
+  if (out.toString.toLowerCase.contains("read-only file system"))
+    sys.error(s"entrypoint wrote to its read-only CWD - the CWD-writing entrypoint has regressed:\n$out")
+}

--- a/src/sbt-test/spark/smoke/project/plugins.sbt
+++ b/src/sbt-test/spark/smoke/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.snowplowanalytics" % "sbt-snowplow-release" % x)
+  case None    => sys.error("The system property 'plugin.version' is not defined.")
+}

--- a/src/sbt-test/spark/smoke/src/main/scala/example/Main.scala
+++ b/src/sbt-test/spark/smoke/src/main/scala/example/Main.scala
@@ -1,0 +1,40 @@
+package example
+
+import cats.syntax.foldable._
+import org.apache.spark.sql.SparkSession
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    // Proves the wrapper entrypoint's "--" sentinel split actually forwards
+    // post-separator tokens to the application at runtime (not just that
+    // spark-submit accepted the pre-separator options and the job ran).
+    require(
+      args.contains("--smoke-marker"),
+      s"self-deploying entrypoint did not forward the application arg past '--'; got: ${args.mkString(" ")}"
+    )
+
+    // Checks the fat jar actually carries the app's own, non-Spark dependency.
+    // combineAll uses cats' Monoid[Int], a class that exists only in cats-core
+    // (Spark ships no cats-* jar), so if cats didn't make it into the assembly
+    // this throws NoClassDefFoundError before Spark even starts a job.
+    val total = List(1, 2, 3).combineAll
+    require(total == 6, s"cats-core not on the app classpath: got $total")
+
+    val spark = SparkSession.builder().appName("snowplow-spark-smoke").getOrCreate()
+    import spark.implicits._
+    val groups =
+      spark.range(1000000L).repartition(8).groupBy($"id" % 100).count().count()
+    require(groups == 100L, s"expected 100 groups, got $groups")
+
+    // Exercises parquet write + read end to end, so the parquet-jackson bump in
+    // the distribution is genuinely validated (the shuffle above never touches
+    // parquet). /tmp is world-writable in the container and the job runs as UID
+    // 65534, so this write succeeds as nobody.
+    val dir = "file:///tmp/smoke-parquet"
+    spark.range(1000L).toDF("n").write.mode("overwrite").parquet(dir)
+    val readBack = spark.read.parquet(dir).count()
+    require(readBack == 1000L, s"parquet round-trip failed: got $readBack")
+
+    spark.stop()
+  }
+}

--- a/src/sbt-test/spark/smoke/test
+++ b/src/sbt-test/spark/smoke/test
@@ -1,0 +1,4 @@
+> checkLayout
+> Docker/publishLocal
+> smokeRun
+> readOnlyRun

--- a/src/sbt-test/spark/staging/build.sbt
+++ b/src/sbt-test/spark/staging/build.sbt
@@ -1,0 +1,21 @@
+lazy val root = (project in file("."))
+  .enablePlugins(SnowplowSparkPlugin)
+  .settings(scalaVersion := "2.13.18")
+
+TaskKey[Unit]("checkStaged") := {
+  val mappings = stageSparkScripts.value
+  val byPath = mappings.map(_._2).toSet
+  Seq(
+    "spark/bin/spark-submit",
+    "spark/bin/spark-class",
+    "spark/bin/load-spark-env.sh",
+    "spark/entrypoint.sh"
+  ).foreach { p =>
+    if (!byPath.contains(p)) sys.error(s"missing staged mapping: $p")
+  }
+  mappings.foreach { case (f, p) =>
+    if (!f.canExecute) sys.error(s"staged file not executable: $p")
+  }
+  val entry = mappings.collectFirst { case (f, "spark/bin/spark-submit") => f }.get
+  if (!entry.canExecute) sys.error("spark-submit not executable")
+}

--- a/src/sbt-test/spark/staging/project/plugins.sbt
+++ b/src/sbt-test/spark/staging/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.snowplowanalytics" % "sbt-snowplow-release" % x)
+  case None    => sys.error("The system property 'plugin.version' is not defined.")
+}

--- a/src/sbt-test/spark/staging/test
+++ b/src/sbt-test/spark/staging/test
@@ -1,0 +1,1 @@
+> checkStaged


### PR DESCRIPTION
Adds a SnowplowSparkPlugin that packages an application into a Spark distribution image which runs itself as the Spark driver.  This gives us fine control of what libraries are included in the build, so let's us mitigate CVEs more quickly without waiting for a release of the 3rd party spark docker base image.

This will be used for packaging RDB batch transformer into a docker image.  I have half an idea we will use this setup for other spark jobs in future (e.g. a lake maintenance job), and this is why I split it into sbt-snowplow-release.

The other advantage of having it in sbt-snowplow-release is it makes more clear which parts of the build are application-specific and which parts of the build are generic for any spark application.